### PR TITLE
chapter18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,25 @@ name: test
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        options: --health-cmd "mysqladmin ping -h localhost" --health-interval 20s --health-timeout 10s --health-retries 10
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: todo
+          MYSQL_USER: todo
+          MYSQL_PASSWORD: todo
     steps:
     - uses: actions/setup-go@v3
       with:
         go-version: '>=1.18'
     - uses: actions/checkout@v3
+    - run: |
+        go install github.com/k0kubun/sqldef/cmd/mysqldef@latest
+        mysqldef -u todo -p todo -h 127.0.0.1 -P 3306 todo < ./_tools/mysql/schema.sql
     - run: go test ./... -coverprofile=coverage.out
     - name: report coverage
       uses: k1LoW/octocov-action@v0

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 DOCKER_TAG := latest
 build: ## Build docker image to deploy
-	docker build -t keisuke-matsufuji/gotodo:${DOCKER_TAG} \
+	docker build -t budougumi0617/gotodo:${DOCKER_TAG} \
 		--target deploy ./
 
 build-local: ## Build docker image to local development
@@ -23,6 +23,12 @@ ps: ## Check container status
 
 test: ## Execute tests
 	go test -race -shuffle=on ./...
+
+dry-migrate: ## Try migration
+	mysqldef -u todo -p todo -h 127.0.0.1 -P 33306 todo --dry-run < ./_tools/mysql/schema.sql
+
+migrate:  ## Execute migration
+	mysqldef -u todo -p todo -h 127.0.0.1 -P 33306 todo < ./_tools/mysql/schema.sql
 
 help: ## Show options
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/_tools/mysql/conf.d/mysql.cnf
+++ b/_tools/mysql/conf.d/mysql.cnf
@@ -1,0 +1,2 @@
+[mysql]
+default_character_set=utf8mb4

--- a/_tools/mysql/conf.d/mysqld.cnf
+++ b/_tools/mysql/conf.d/mysqld.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+default-authentication-plugin=mysql_native_password
+character_set_server=utf8mb4
+sql_mode=TRADITIONAL,NO_AUTO_VALUE_ON_ZERO,ONLY_FULL_GROUP_BY

--- a/_tools/mysql/schema.sql
+++ b/_tools/mysql/schema.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `user`
+(
+    `id`       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'ユーザーの識別子',
+    `name`     varchar(20) NOT NULL COMMENT 'ユーザー名',
+    `password` VARCHAR(80) NOT NULL COMMENT 'パスワードハッシュ',
+    `role`     VARCHAR(80) NOT NULL COMMENT 'ロール',
+    `created`  DATETIME(6) NOT NULL COMMENT 'レコード作成日時',
+    `modified` DATETIME(6) NOT NULL COMMENT 'レコード修正日時',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uix_name` (`name`) USING BTREE
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='ユーザー';
+
+CREATE TABLE `task`
+(
+    `id`       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'タスクの識別子',
+    `title`    VARCHAR(128) NOT NULL COMMENT 'タスクのタイトル',
+    `status`   VARCHAR(20)  NOT NULL COMMENT 'タスクの状態',
+    `created`  DATETIME(6) NOT NULL COMMENT 'レコード作成日時',
+    `modified` DATETIME(6) NOT NULL COMMENT 'レコード修正日時',
+    PRIMARY KEY (`id`)
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='タスク';

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,0 +1,21 @@
+package clock
+
+import (
+	"time"
+)
+
+type Clocker interface {
+	Now() time.Time
+}
+
+type RealClocker struct{}
+
+func (r RealClocker) Now() time.Time {
+	return time.Now()
+}
+
+type FixedClocker struct{}
+
+func (fc FixedClocker) Now() time.Time {
+	return time.Date(2022, 5, 10, 12, 34, 56, 0, time.UTC)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -5,8 +5,13 @@ import (
 )
 
 type Config struct {
-	Env  string `env:"TODO_ENV" envDefault:"dev"`
-	Port int    `env:"PORT" envDefault:"80"`
+	Env        string `env:"TODO_ENV" envDefault:"dev"`
+	Port       int    `env:"PORT" envDefault:"80"`
+	DBHost     string `env:"TODO_DB_HOST" envDefault:"127.0.0.1"`
+	DBPort     int    `env:"TODO_DB_PORT" envDefault:"33306"`
+	DBUser     string `env:"TODO_DB_USER" envDefault:"todo"`
+	DBPassword string `env:"TODO_DB_PASSWORD" envDefault:"todo"`
+	DBName     string `env:"TODO_DB_NAME" envDefault:"todo"`
 }
 
 func New() (*Config, error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,30 @@ services:
     environment:
       TODO_ENV: dev
       PORT: 8080
+      TODO_DB_HOST: todo-db
+      TODO_DB_PORT: 3306
+      TODO_DB_USER: todo
+      TODO_DB_PASSWORD: todo
+      TODO_DB_NAME: todo
     volumes:
       - .:/app
     ports:
       - "18000:8080"
+    links:
+      - todo-db
+  todo-db:
+    image: mysql:8.0.29
+    platform: linux/amd64
+    container_name: todo-db
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_USER: todo
+      MYSQL_PASSWORD: todo
+      MYSQL_DATABASE: todo
+    volumes:
+      - todo-db-data:/var/lib/mysql
+      - $PWD/_tools/mysql/conf.d:/etc/mysql/conf.d:cached
+    ports:
+      - "33306:3306"
+volumes:
+  todo-db-data:

--- a/entity/task.go
+++ b/entity/task.go
@@ -12,10 +12,11 @@ const (
 )
 
 type Task struct {
-	ID      TaskID     `json:"id"`
-	Title   string     `json:"title"`
-	Status  TaskStatus `json:"status" `
-	Created time.Time  `json:"created"`
+	ID       TaskID     `json:"id" db:"id"`
+	Title    string     `json:"title" db:"title"`
+	Status   TaskStatus `json:"status" db:"status"`
+	Created  time.Time  `json:"created" db:"created"`
+	Modified time.Time  `json:"modified" db:"modified"`
 }
 
 type Tasks []*Task

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,15 @@ go 1.19
 require golang.org/x/sync v0.0.0-20220907140024-f12130a52804
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/caarlos0/env/v6 v6.10.1 // indirect
 	github.com/go-chi/chi/v5 v5.0.7 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.11.0 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
 	golang.org/x/sys v0.0.0-20220913120320-3275c407cedc // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
 github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -12,8 +14,12 @@ github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/j
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
 github.com/go-playground/validator/v10 v10.11.0 h1:0W+xRM511GY47Yy3bZUbJVitCNg2BOGlCyvTqsp/xIw=
 github.com/go-playground/validator/v10 v10.11.0/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
+github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
@@ -22,6 +28,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/store/repository.go
+++ b/store/repository.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+	"github.com/keisuke-matsufuji/go_todo_app/clock"
+	"github.com/keisuke-matsufuji/go_todo_app/config"
+)
+
+const (
+	// ErrCodeMySQLDuplicateEntry はMySQL系ののDUPLICATEエラーコード
+	// https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+	// Error number: 1062; Symbol: ER_DUP_ENTRY; SQLSTATE: 23000
+	ErrCodeMySQLDuplicateEntry = 1062
+)
+
+var (
+	ErrAlreadyEntry = errors.New("duplicate entry")
+)
+
+func New(ctx context.Context, cfg *config.Config) (*sqlx.DB, func(), error) {
+	// sqlx.Connectを使うと内部でpingする。
+	db, err := sql.Open("mysql",
+		fmt.Sprintf(
+			"%s:%s@tcp(%s:%d)/%s?parseTime=true",
+			cfg.DBUser, cfg.DBPassword,
+			cfg.DBHost, cfg.DBPort,
+			cfg.DBName,
+		),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Openは実際に接続テストが行われない。
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		return nil, func() { _ = db.Close() }, err
+	}
+	xdb := sqlx.NewDb(db, "mysql")
+	return xdb, func() { _ = db.Close() }, nil
+}
+
+type Repository struct {
+	Clocker clock.Clocker
+}
+
+type Beginner interface {
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+
+type Preparer interface {
+	PreparexContext(ctx context.Context, query string) (*sqlx.Stmt, error)
+}
+
+type Execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error)
+}
+
+type Queryer interface {
+	Preparer
+	QueryxContext(ctx context.Context, query string, args ...any) (*sqlx.Rows, error)
+	QueryRowxContext(ctx context.Context, query string, args ...any) *sqlx.Row
+	GetContext(ctx context.Context, dest interface{}, query string, args ...any) error
+	SelectContext(ctx context.Context, dest interface{}, query string, args ...any) error
+}
+
+var (
+	// インターフェイスが期待通りに宣言されているか確認
+	_ Beginner = (*sqlx.DB)(nil)
+	_ Preparer = (*sqlx.DB)(nil)
+	_ Queryer  = (*sqlx.DB)(nil)
+	_ Execer   = (*sqlx.DB)(nil)
+	_ Execer   = (*sqlx.Tx)(nil)
+)

--- a/store/task.go
+++ b/store/task.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"context"
+
+	"github.com/keisuke-matsufuji/go_todo_app/entity"
+)
+
+func (r *Repository) AddTask(
+	ctx context.Context, db Execer, t *entity.Task,
+) error {
+	t.Created = r.Clocker.Now()
+	t.Modified = r.Clocker.Now()
+	sql := `INSERT INTO task
+		(title, status, created, modified)
+	VALUES (?, ?, ?, ?)`
+	result, err := db.ExecContext(
+		ctx, sql, t.Title, t.Status,
+		t.Created, t.Modified,
+	)
+	if err != nil {
+		return err
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return err
+	}
+	t.ID = entity.TaskID(id)
+	return nil
+}
+
+func (r *Repository) ListTasks(
+	ctx context.Context, db Queryer,
+) (entity.Tasks, error) {
+	tasks := entity.Tasks{}
+	sql := `SELECT
+			id, title,
+			status, created, modified
+		FROM task;`
+	if err := db.SelectContext(ctx, &tasks, sql); err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}

--- a/store/task_test.go
+++ b/store/task_test.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/jmoiron/sqlx"
+	"github.com/keisuke-matsufuji/go_todo_app/clock"
+	"github.com/keisuke-matsufuji/go_todo_app/entity"
+	"github.com/keisuke-matsufuji/go_todo_app/testutil"
+)
+
+func prepareTasks(ctx context.Context, t *testing.T, con Execer) entity.Tasks {
+	t.Helper()
+	// 一度きれいにしておく
+	if _, err := con.ExecContext(ctx, "DELETE FROM task;"); err != nil {
+		t.Logf("failed to initialize task: %v", err)
+	}
+	c := clock.FixedClocker{}
+	wants := entity.Tasks{
+		{
+			Title: "want task 1", Status: "todo",
+			Created: c.Now(), Modified: c.Now(),
+		},
+		{
+			Title: "want task 2", Status: "todo",
+			Created: c.Now(), Modified: c.Now(),
+		},
+		{
+			Title: "want task 3", Status: "done",
+			Created: c.Now(), Modified: c.Now(),
+		},
+	}
+	result, err := con.ExecContext(ctx,
+		`INSERT INTO task (title, status, created, modified)
+			VALUES
+			    (?, ?, ?, ?),
+			    (?, ?, ?, ?),
+			    (?, ?, ?, ?);`,
+		wants[0].Title, wants[0].Status, wants[0].Created, wants[0].Modified,
+		wants[1].Title, wants[1].Status, wants[1].Created, wants[1].Modified,
+		wants[2].Title, wants[2].Status, wants[2].Created, wants[2].Modified,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wants[0].ID = entity.TaskID(id)
+	wants[1].ID = entity.TaskID(id + 1)
+	wants[2].ID = entity.TaskID(id + 2)
+	return wants
+}
+
+func TestRepository_ListTasks(t *testing.T) {
+	ctx := context.Background()
+	// entity.Taskを作成する他のテストケースと混ざるとテストがフェイルする。
+	// そのため、トランザクションをはることでこのテストケースの中だけのテーブル状態にする。
+	tx, err := testutil.OpenDBForTest(t).BeginTxx(ctx, nil)
+	// このテストケースが完了したら元に戻す
+	t.Cleanup(func() { _ = tx.Rollback() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	wants := prepareTasks(ctx, t, tx)
+
+	sut := &Repository{}
+	gots, err := sut.ListTasks(ctx, tx)
+	if err != nil {
+		t.Fatalf("unexected error: %v", err)
+	}
+	if d := cmp.Diff(gots, wants); len(d) != 0 {
+		t.Errorf("differs: (-got +want)\n%s", d)
+	}
+}
+
+func TestRepository_AddTask(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	c := clock.FixedClocker{}
+	var wantID int64 = 20
+	okTask := &entity.Task{
+		Title:    "ok task",
+		Status:   "todo",
+		Created:  c.Now(),
+		Modified: c.Now(),
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	mock.ExpectExec(
+		// エスケープが必要
+		`INSERT INTO task \(title, status, created, modified\) VALUES \(\?, \?, \?, \?\)`,
+	).WithArgs(okTask.Title, okTask.Status, c.Now(), c.Now()).
+		WillReturnResult(sqlmock.NewResult(wantID, 1))
+
+	xdb := sqlx.NewDb(db, "mysql")
+	r := &Repository{Clocker: c}
+	if err := r.AddTask(ctx, xdb, okTask); err != nil {
+		t.Errorf("want no error, but got %v", err)
+	}
+}

--- a/testutil/db.go
+++ b/testutil/db.go
@@ -1,0 +1,29 @@
+package testutil
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+)
+
+func OpenDBForTest(t *testing.T) *sqlx.DB {
+	port := 33306
+	if _, defined := os.LookupEnv("CI"); defined {
+		port = 3306
+	}
+	db, err := sql.Open(
+		"mysql",
+		fmt.Sprintf("todo:todo@tcp(127.0.0.1:%d)/todo?parseTime=true", port),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(
+		func() { _ = db.Close() },
+	)
+	return sqlx.NewDb(db, "mysql")
+}


### PR DESCRIPTION
## 72
- Goはアンダースコアで名前が始まるディレクトリおよび`testdata`という名前のディレクトリをパッケージとして認識しない
- マイグレーションツールで[https://github.com/k0kubun/sqldef](https://github.com/k0kubun/sqldef)を使う
- [https://github.com/k0kubun/sqldef](https://github.com/k0kubun/sqldef)はdry-runモードもある
- GitHub Actionsではサービスコンテナという方法でCI/CDワークフロー上で必要になるミドルウェアのコンテナを起動できる。

## 73
- `database/sql`パッケージを使った場合、データベースから取得したレコードの情報を構造体にマッピングする実装を毎回行う必要がある
- [sqlx](https://github.com/jmoiron/sqlx)を使う場合、構造体の各フィールドにタグでテーブルカラム名に対応したメタデータを設定しておく。
- `sql.Open`関数は接続確認までは行わないため、明示的に`*sql.DB.Close`メソッドを呼び出してコネクションを正しく終了する必要がある
- `New`関数の中ではアプリケーションの終了に合わせて`*sql.DB.Close`メソッドを呼び出すことはできない。代わりに、`New`関数呼び出しもとで終了処理をできるように戻り値として`*sql.DB.Close`メソッドを実行する無名関数を返す。
- clock.Clockerパッケージを作って、Clockerインターフェースを作成。Clockerインターフェースを満たす実装として、`RealClocker`と`FixedClocker`の実装を作った。このようにすることで、実際の時刻と、テスト用の固定された時刻とで実装を分けることができる

## 74
- INSERT文で複数のレコードを作ったときの`sql.Result.LastInsertId`メソッドの戻り値のIDは、MySQLでは1つ目のレコードのIDになる。
- 単体テストに相当するテストコードでRDBMSに依存したテストコードを書きたくない場合、[https://github.com/DATA-DOG/go-sqlmock](https://github.com/DATA-DOG/go-sqlmock)を使う。トランザクションを利用する実装だった場合、COMMIT/ROLLBACKが期待通り発行されたのかも検証できる。